### PR TITLE
Have .travis.yml handle the test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,11 @@ go:
 git:
   depth: 3
 
+install:
+  - go get "github.com/ConfWatch/confwatchd"
+  - cd "${GOPATH}/src/github.com/ConfWatch/confwatchd"
+  - make
+
 script:
-  - ./travis-test-script.sh
+  - ./confwatchd -config dev-config.json -seed "${TRAVIS_BUILD_DIR}/"
+

--- a/main.go
+++ b/main.go
@@ -1,5 +1,0 @@
-package main
-
-func main() {
-
-}

--- a/travis-test-script.sh
+++ b/travis-test-script.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-go get "github.com/ConfWatch/confwatchd" && 
-cd "$GOPATH/src/github.com/ConfWatch/confwatchd" &&
-make && 
-./confwatchd -config dev-config.json -seed "$GOPATH/src/github.com/ConfWatch/confwatch-data/"


### PR DESCRIPTION
This removes the need for the main.go file by overriding the "install" step and puts fetching and building of confwatchd into the travis.yml removing the need for the wrapper script. And should solve #1 