### PR TITLE
add sstic 2018

### DIFF
--- a/events/sstic/editions/sstic-2018.json
+++ b/events/sstic/editions/sstic-2018.json
@@ -1,0 +1,13 @@
+{
+	"title": "SSTIC 2018",
+	"type": 0,
+	"description": "SSTIC, édition 2018",
+	"website": "https://www.sstic.org/2018/",
+	"country": "FR",
+	"city": "Rennes",
+	"address": "Le Couvent des Jacobins, centre des congrès de Rennes. Place Sainte Anne, 35000 Rennes, France",
+	"starts": "2018-06-13T10:00:00+02:00",
+	"ends": "2018-06-15T17:00:00+02:00",
+	"tags": "sstic",
+	"attributes": []
+}


### PR DESCRIPTION
## Purpose

 #24 was missing next (2018) edition, so add that. Sorry for all that duplicate work.

## Sources
https://www.sstic.org/2018/