### PR TITLE
Created new attribute - speaker funding

### DIFF
--- a/attributes/speaker-funding
+++ b/attributes/speaker-funding
@@ -1,0 +1,5 @@
+
+{
+   "title": "Speaker Funding",
+   "description": "This event provides travel funding to accepted speakers."
+}


### PR DESCRIPTION
Created attribute to indicate whether an event will pay for accepted speaker's travel. As someone who likes to apply to speak at conferences this would be a great way to filter conferences that i might consider applying to.

## Purpose

- Added `speaker-funding` attribute. 

