### PR TITLE
Adding Internet Freedom Festival

### DIFF
--- a/categories/InternetCommunity.json
+++ b/categories/InternetCommunity.json
@@ -1,0 +1,4 @@
+{
+   "title": "InternetCommunity",
+   "description": "Community-driven conference and festival"
+}

--- a/events/iff/Editions/IFF-2018.json
+++ b/events/iff/Editions/IFF-2018.json
@@ -9,5 +9,5 @@
 	"starts": "2018-03-5T09:30:00+01:00",
 	"ends": "2018-03-9T20:30:00+01:00",
     "tags": "iff18",
-	"attributes": "code-of-conduct",
+	"attributes": ["code-of-conduct"]
 }

--- a/events/iff/Editions/IFF-2018.json
+++ b/events/iff/Editions/IFF-2018.json
@@ -1,0 +1,13 @@
+{
+	"title": "Internet Freedom Festival 2018",
+	"type": 0,
+	"description": "Since its beginning as the Circumvention Tech Festival in 2015, the Internet Freedom Festival (IFF) has grown into one of the largest, most diverse and inclusive gatherings in the Internet Freedom community. Each year, the IFF brings together those who defend digital rights around the world – journalists, activists, technologists, policy advocates, digital safety trainers, and designers – in support of digital rights and online freedom expression.",
+	"website": "https://internetfreedomfestival.org/",
+	"country": "ES",
+	"city": "Valencia",
+	"address": "Calle de Juan Verdeguer 16,",
+	"starts": "2018-03-5T09:30:00+01:00",
+	"ends": "2018-03-9T20:30:00+01:00",
+    "tags": "iff18",
+	"attributes": ["code-of-conduct"]
+}

--- a/events/iff/Editions/IFF-2018.json
+++ b/events/iff/Editions/IFF-2018.json
@@ -9,5 +9,5 @@
 	"starts": "2018-03-5T09:30:00+01:00",
 	"ends": "2018-03-9T20:30:00+01:00",
     "tags": "iff18",
-	"attributes": ["code-of-conduct"]
+	"attributes": "code-of-conduct",
 }

--- a/events/iff/Editions/iff-2018.json
+++ b/events/iff/Editions/iff-2018.json
@@ -1,6 +1,13 @@
 {
-	"title": "Internet Freedom Festival",
+	"title": "Internet Freedom Festival 2018",
+	"type": 0,
 	"description": "Since its beginning as the Circumvention Tech Festival in 2015, the Internet Freedom Festival (IFF) has grown into one of the largest, most diverse and inclusive gatherings in the Internet Freedom community. Each year, the IFF brings together those who defend digital rights around the world – journalists, activists, technologists, policy advocates, digital safety trainers, and designers – in support of digital rights and online freedom expression.",
 	"website": "https://internetfreedomfestival.org/",
-    	"categories": [ "internetcommunity" ]
+	"country": "ES",
+	"city": "Valencia",
+	"address": "Calle de Juan Verdeguer 16",
+	"starts": "2018-03-5T09:30:00+01:00",
+	"ends": "2018-03-9T20:30:00+01:00",
+    "tags": "iff18",
+	"attributes": ["code-of-conduct"]
 }

--- a/events/iff/event.json
+++ b/events/iff/event.json
@@ -1,0 +1,6 @@
+{
+	"title": "Internet Freedom Festival",
+	"description": "Since its beginning as the Circumvention Tech Festival in 2015, the Internet Freedom Festival (IFF) has grown into one of the largest, most diverse and inclusive gatherings in the Internet Freedom community. Each year, the IFF brings together those who defend digital rights around the world – journalists, activists, technologists, policy advocates, digital safety trainers, and designers – in support of digital rights and online freedom expression.",
+	"website": "https://internetfreedomfestival.org/",
+    "categories": [ "InternetCommunity" ]
+}

--- a/events/iff/event.json
+++ b/events/iff/event.json
@@ -2,5 +2,5 @@
 	"title": "Internet Freedom Festival",
 	"description": "Since its beginning as the Circumvention Tech Festival in 2015, the Internet Freedom Festival (IFF) has grown into one of the largest, most diverse and inclusive gatherings in the Internet Freedom community. Each year, the IFF brings together those who defend digital rights around the world – journalists, activists, technologists, policy advocates, digital safety trainers, and designers – in support of digital rights and online freedom expression.",
 	"website": "https://internetfreedomfestival.org/",
-    "categories": "InternetCommunity"
+    "categories": ["InternetCommunity"]
 }

--- a/events/iff/event.json
+++ b/events/iff/event.json
@@ -2,5 +2,5 @@
 	"title": "Internet Freedom Festival",
 	"description": "Since its beginning as the Circumvention Tech Festival in 2015, the Internet Freedom Festival (IFF) has grown into one of the largest, most diverse and inclusive gatherings in the Internet Freedom community. Each year, the IFF brings together those who defend digital rights around the world – journalists, activists, technologists, policy advocates, digital safety trainers, and designers – in support of digital rights and online freedom expression.",
 	"website": "https://internetfreedomfestival.org/",
-    "categories": [ "InternetCommunity" ]
+    "categories": "InternetCommunity"
 }


### PR DESCRIPTION
## Purpose

Adding Internet Freedom Festival and the new category Internet Community, related to conferences organized following a community-driven approach and focused on internet community issues at large.

## Sources

https://internetfreedomfestival.org/
https://www.internetfreedomfestival.org/wiki/index.php/Code_of_Conduct


