### PR TITLE
fixed dates for OWASP Open Security Summit

### DIFF
--- a/events/owasp/editions/open-security-summit-2018.json
+++ b/events/owasp/editions/open-security-summit-2018.json
@@ -6,8 +6,8 @@
     "country": "UK",
     "city": "Bedfordshire",
     "address": "Woburn Forest Center Parcs, Millbrook Rd, Bedford MK45 2HZ",
-    "starts": "2018-08-04T09:00:00+01:00",
-    "ends": "2018-08-08T20:00:00+01:00",
+    "starts": "2018-06-04T09:00:00+01:00",
+    "ends": "2018-06-08T20:00:00+01:00",
     "tags": "owasp,open-security-summit",
     "attributes": []
 }


### PR DESCRIPTION
## Purpose

fixed dates for OWASP Open Security Summit. June instead of August

#### Open Questions and Pre-Merge TODOs

*  https://open-security-summit.org/


