### PR TITLE
Added new category for conferences that offer trainings

### DIFF
--- a/categories/trainings.json
+++ b/categories/trainings.json
@@ -1,0 +1,5 @@
+{
+    "title": "trainings",
+    "description": "Conferences offers Trainings"
+ }
+ 


### PR DESCRIPTION
## Purpose

I wish mode metadata would be available for choosing the right conferences. Especially, if a conference also offers trainings. The added solution adds a new category for that purpose.


