### PR TITLE
Event renaming

### DIFF
--- a/events/nuit-du-hack/event.json
+++ b/events/nuit-du-hack/event.json
@@ -1,6 +1,6 @@
 {
-	"title": "Nuit du Hack",
+	"title": "leHACK",
 	"description": "The biggest French hacking event",
-	"website": "https://nuitduhack.com",
+	"website": "https://lehack.org",
     "categories": [ "infosec" ]
 }


### PR DESCRIPTION
Nuit du hack ended, and rebooted under the name " leHACK " dur to a copyright dispute.
The organizing team ( HZV ) is the same, the value stays the same.
https://www.nextinpact.com/news/106806-la-nuit-hack-devient-lehack-pour-rester-independante.htm

## Purpose

_Describe the data that has been added and/or updated._

#### Open Questions and Pre-Merge TODOs

- [ ] Use github checklists. When solved, check the box and explain the answer.

## Sources

_The sources you used_


