### PR TITLE
add Pass the Salt French conference

### DIFF
--- a/events/pass-the-salt/editions/pts-2018.json
+++ b/events/pass-the-salt/editions/pts-2018.json
@@ -1,0 +1,13 @@
+{
+	"title": "Pass the Salt 2018",
+	"type": 0,
+	"description": "Pass the Salt, édition 2018",
+	"website": "https://2018.pass-the-salt.org",
+	"country": "FR",
+	"city": "Lille",
+	"address": "Polytech Lille engineer school, Avenue Paul Langevin, 59655 Villeneuve d'Ascq",
+	"starts": "2018-07-02T14:00:00+02:00",
+	"ends": "2018-07-04T17:30:00+02:00",
+	"tags": "pts18",
+	"attributes": []
+}

--- a/events/pass-the-salt/editions/pts-2019.json
+++ b/events/pass-the-salt/editions/pts-2019.json
@@ -1,0 +1,13 @@
+{
+	"title": "Pass the Salt 2019",
+	"type": 0,
+	"description": "Pass the Salt, édition 2019",
+	"website": "https://2019.pass-the-salt.org",
+	"country": "FR",
+	"city": "Lille",
+	"address": "Polytech Lille engineer school, Avenue Paul Langevin, 59655 Villeneuve d'Ascq",
+	"starts": "2019-07-01T14:00:00+02:00",
+	"ends": "2019-07-03T17:00:00+02:00",
+	"tags": "pts19",
+	"attributes": []
+}

--- a/events/pass-the-salt/event.json
+++ b/events/pass-the-salt/event.json
@@ -1,0 +1,6 @@
+{
+  "title": "Pass the salt",
+  "description": "A free Security & Free Software conference. Building bridges between Security communities and Free Software hackers!",
+  "website": "https://www.pass-the-salt.org/",
+  "categories": ["infosec"]
+}


### PR DESCRIPTION
## Purpose
Add Pass the Salt French conference, 2018 and 2019 editions.

## Sources
Conference website at https://www.pass-the-salt.org


