### PR TITLE
add SSTIC 2019

### DIFF
--- a/events/sstic/editions/sstic-2019.json
+++ b/events/sstic/editions/sstic-2019.json
@@ -1,0 +1,13 @@
+{
+	"title": "SSTIC 2019",
+	"type": 0,
+	"description": "SSTIC, édition 2019",
+	"website": "https://www.sstic.org/2019/",
+	"country": "FR",
+	"city": "Rennes",
+	"address": "Le Couvent des Jacobins, centre des congrès de Rennes. Place Sainte Anne, 35000 Rennes, France",
+	"starts": "2019-06-05T10:00:00+02:00",
+	"ends": "2019-06-07T17:00:00+02:00",
+	"tags": "sstic",
+	"attributes": []
+}


### PR DESCRIPTION
## Purpose

Add the 2019 edition of SSTIC French conference
## Sources
Conference website (https://www.sstic.org/2019/news/)


